### PR TITLE
Added Cross-Plugin Support to PreviewMessage

### DIFF
--- a/PreviewMessage/PreviewMessage.plugin.js
+++ b/PreviewMessage/PreviewMessage.plugin.js
@@ -2,7 +2,7 @@
 * @name PreviewMessage
 * @author DaddyBoard
 * @authorId 241334335884492810
-* @version 1.1.0
+* @version 1.2.0
 * @description Allows you to preview a message before you send it. Original idea by TheCommieAxolotl, rewritten and maintained by DaddyBoard.
 * @source https://github.com/DaddyBoard/BD-Plugins
 * @invite ggNWGDV7e2
@@ -28,7 +28,7 @@ function PreviewButton({ channel }) {
                 onClick: () => {
                     const draft = DraftStore.getDraft(channel.id, 0);
                     if (draft) {
-                        if (draft.length > 2000 && Plugins.isEnabled("SplitLargeMessages")){
+                        if (Plugins.isEnabled("SplitLargeMessages")){
                             const messageSplitter = Plugins.get("SplitLargeMessages").instance;
 
                             var splitMessages = [""];
@@ -39,15 +39,15 @@ function PreviewButton({ channel }) {
                             } catch (e){
                                 MessageActions.sendBotMessage(channel.id, "Warning: SplitLargeMessages threw an error and likely won't split your messages or the developer changed how splitting is implemented.")
                             }
-                            if (splitMessages.length > 1){
-                                for (const message of splitMessages){
-                                    MessageActions.sendBotMessage(channel.id, format(message, channel.id));
-                                }
+
+                            for (const message of splitMessages){
+                                MessageActions.sendBotMessage(channel.id, format(message, channel.id));
                             }
+                        }else{
+
+                            MessageActions.sendBotMessage(channel.id, format(draft, channel.id));
+
                         }
-
-
-                        MessageActions.sendBotMessage(channel.id, format(draft, channel.id));
                     }
                 }
             },
@@ -97,27 +97,6 @@ function format(originalText, cID){
         }
     }
 
-    if (Plugins.isEnabled("Zalgo")){
-        
-        const zalgo = Plugins.get("Zalgo").instance;
-        try{
-            if (zalgo?.doZalgo){
-                const escapeSpecial = str => str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-                const startChars = escapeSpecial(zalgo.settings.startCharacters || '{{');
-                const endChars = escapeSpecial(zalgo.settings.endCharacters || '}}');
-                const regex = new RegExp(startChars + "(?:(?:(?:(o|b))?,?)?(?:(r)(\d+(?:\.\d+)?)?,?)?(?:(\d+(?:\.\d+)?)-)?(\d+(?:\.\d+)?)?\:)?((?:(?!{{).)*?)" + endChars);
-                if (regex.test(text)){                        
-                    text = text.replace(regex, zalgo.doZalgo.bind(zalgo));
-                    if (text.length > 2000) {
-                        MessageActions.sendBotMessage(cID, "The following message exceeded 2000 characters due to Zalgo and may not be able to sent.");
-                    }
-                }
-            }
-        } catch (e){
-            MessageActions.sendBotMessage(cID, "Warning: Zalgo threw an error and likely won't format your text or the developer changed how the plugin changes text.\n"+e);
-        }
-    }
-
     if (Plugins.isEnabled("BetterFormattingRedux")){
         
         const betterFormatting = Plugins.get("BetterFormattingRedux").instance;
@@ -126,7 +105,7 @@ function format(originalText, cID){
                 text = betterFormatting.format(text);
             }
         } catch (e){
-            MessageActions.sendBotMessage(cID, "Warning: BetterFormattingRedux threw an error and likely won't format your text or the developted changed how the plugin changes text.");
+            MessageActions.sendBotMessage(cID, "Warning: BetterFormattingRedux threw an error and likely won't format your text or the developter changed how the plugin changes text.");
         }
     }
 
@@ -138,7 +117,7 @@ function format(originalText, cID){
                 text = vriska.processText(text);
             }
         } catch (e){
-            MessageActions.sendBotMessage(cID, "Warning: Vriska'sTypingQuirk threw an error and likely won't format your text or the developted changed how the plugin changes text.");
+            MessageActions.sendBotMessage(cID, "Warning: Vriska'sTypingQuirk threw an error and likely won't format your text or the developter changed how the plugin changes text.");
         }
     }
 

--- a/PreviewMessage/PreviewMessage.plugin.js
+++ b/PreviewMessage/PreviewMessage.plugin.js
@@ -8,7 +8,7 @@
 * @invite ggNWGDV7e2
 */
 
-const { Webpack, React, Patcher } = BdApi;
+const { Webpack, React, Patcher, Plugins } = BdApi;
 
 const DraftStore = Webpack.getModule((m) => m.getDraft);
 const MessageActions = Webpack.getModule((m) => m.sendBotMessage);
@@ -27,7 +27,28 @@ function PreviewButton({ channel }) {
                 style: { padding: "5px" },
                 onClick: () => {
                     const draft = DraftStore.getDraft(channel.id, 0);
-                    if (draft) MessageActions.sendBotMessage(channel.id, draft);
+                    if (draft) {
+                        if (draft.length > 2000 && Plugins.isEnabled("SplitLargeMessages")){
+                            const messageSplitter = Plugins.get("SplitLargeMessages").instance;
+
+                            var splitMessages = [""];
+                            try{
+                                if (messageSplitter?.formatText){
+                                    splitMessages = messageSplitter.formatText(draft)
+                                }
+                            } catch (e){
+                                MessageActions.sendBotMessage(channel.id, "Warning: SplitLargeMessages threw an error and likely won't split your messages or the developer changed how splitting is implemented.")
+                            }
+                            if (splitMessages.length > 1){
+                                for (const message of splitMessages){
+                                    MessageActions.sendBotMessage(channel.id, format(message, channel.id));
+                                }
+                            }
+                        }
+
+
+                        MessageActions.sendBotMessage(channel.id, format(draft, channel.id));
+                    }
                 }
             },
             React.createElement(ChatButton, null,
@@ -59,6 +80,70 @@ function PreviewButton({ channel }) {
             )
         )
     );
+}
+
+function format(originalText, cID){
+    var text = originalText;
+
+    if (Plugins.isEnabled("ChatAliases")){
+        
+        const chatAliases = Plugins.get("ChatAliases").instance;
+        try{
+            if (chatAliases?.formatText && chatAliases.settings.places.normal){
+                text = chatAliases.formatText(text).text;
+            }
+        } catch (e){
+            MessageActions.sendBotMessage(cID, "Warning: ChatAliases threw an error and likely won't format your text or the developer changed how the plugin changes text.");
+        }
+    }
+
+    if (Plugins.isEnabled("Zalgo")){
+        
+        const zalgo = Plugins.get("Zalgo").instance;
+        try{
+            if (zalgo?.doZalgo){
+                const escapeSpecial = str => str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+                const startChars = escapeSpecial(zalgo.settings.startCharacters || '{{');
+                const endChars = escapeSpecial(zalgo.settings.endCharacters || '}}');
+                const regex = new RegExp(startChars + "(?:(?:(?:(o|b))?,?)?(?:(r)(\d+(?:\.\d+)?)?,?)?(?:(\d+(?:\.\d+)?)-)?(\d+(?:\.\d+)?)?\:)?((?:(?!{{).)*?)" + endChars);
+                if (regex.test(text)){                        
+                    text = text.replace(regex, zalgo.doZalgo.bind(zalgo));
+                    if (text.length > 2000) {
+                        MessageActions.sendBotMessage(cID, "The following message exceeded 2000 characters due to Zalgo and may not be able to sent.");
+                    }
+                }
+            }
+        } catch (e){
+            MessageActions.sendBotMessage(cID, "Warning: Zalgo threw an error and likely won't format your text or the developer changed how the plugin changes text.\n"+e);
+        }
+    }
+
+    if (Plugins.isEnabled("BetterFormattingRedux")){
+        
+        const betterFormatting = Plugins.get("BetterFormattingRedux").instance;
+        try{
+            if (betterFormatting?.format){
+                text = betterFormatting.format(text);
+            }
+        } catch (e){
+            MessageActions.sendBotMessage(cID, "Warning: BetterFormattingRedux threw an error and likely won't format your text or the developted changed how the plugin changes text.");
+        }
+    }
+
+    if (Plugins.isEnabled("Vriska'sTypingQuirk")){
+
+        const vriska = Plugins.get("Vriska'sTypingQuirk").instance;
+        try{
+            if (vriska?.processText){
+                text = vriska.processText(text);
+            }
+        } catch (e){
+            MessageActions.sendBotMessage(cID, "Warning: Vriska'sTypingQuirk threw an error and likely won't format your text or the developted changed how the plugin changes text.");
+        }
+    }
+
+
+    return text;
 }
 
 module.exports = class PreviewMessage {


### PR DESCRIPTION
Adds in support for all plugins currently on the plugin store that change the text sent. This is done to make the plugin better reflect what you will actually send if you're using these plugins. These changes make this plugin much more helo

The plugins supported include:

- BetterFormattingRedux 
- ChatAliases
- Vriska'sTypingQuirk
- SplitLongMessages
- Zalgo (technically no longer on the plugin store but)

Most of the cross-compatibilities work by simply calling the other plugin's functions, so no extra work is needed on this plugin's end to make sure things behave properly beyond simply applying the plugin's formatting method to the text.

Zalgo does do some extra set up to make sure the method actually runs properly, plus Zalgo is a discontinued plugin that was largely just implemented for fun. Feel free to remove the Zalgo plugin.

SplitLargeMessages also has some additional set up to make sure it sends each individual message as an individual preview message, but since this is still an actively developed plugin that can occasionally mess up the formatting of messages depending on how they're split, it is worth including.


The added plugin compatibility should have the proper priorities given to each plugin to make sure the result of the final preview matches what the real message would say even if the plugins would conflict with one another.