### PR TITLE
Fix MoreRoleColors with gradients

### DIFF
--- a/MoreRoleColors/MoreRoleColors.plugin.js
+++ b/MoreRoleColors/MoreRoleColors.plugin.js
@@ -432,14 +432,27 @@ module.exports = class MoreRoleColors {
     injectCSS() {
         BdApi.DOM.addStyle("MoreRoleColors", `
             [class*="markup_"] code,
-            [class*="markup_"] pre,
+            [class*="markup_"] pre {
+                color: var(--text-default, var(--text-normal, #dbdee1)) !important;
+                -webkit-text-fill-color: currentColor !important;
+            }
+
+            [class*="markup_"] code * {
+                -webkit-text-fill-color: currentColor !important;
+            }
+
             [class*="markup_"] [class*="mention"],
             [class*="markup_"] [class*="roleMention"],
             [class*="markup_"] a,
             [class*="markup_"] [class*="timestamp"],
             [class*="markup_"] [class*="spoilerContent"],
             [class*="markup_"] [class*="blockquoteContent"] {
-                -webkit-text-fill-color: initial !important;
+                -webkit-text-fill-color: currentColor !important;
+            }
+
+            [class*="poll" i],
+            [class*="poll" i] * {
+                -webkit-text-fill-color: currentColor !important;
             }
         `);
     }
@@ -478,7 +491,7 @@ module.exports = class MoreRoleColors {
             }
 
             element.style = {
-                color: "unset",
+                color: "var(--text-default, var(--text-normal, #dbdee1))",
                 background: `${gradient} text`,
                 WebkitBackgroundClip: "text",
                 WebkitTextFillColor: "transparent"

--- a/MoreRoleColors/MoreRoleColors.plugin.js
+++ b/MoreRoleColors/MoreRoleColors.plugin.js
@@ -441,6 +441,11 @@ module.exports = class MoreRoleColors {
                 -webkit-text-fill-color: currentColor !important;
             }
 
+            [class*="markup_"] s,
+            [class*="markup_"] del {
+                text-decoration-color: var(--text-default, var(--text-normal, #dbdee1)) !important;
+            }
+
             [class*="markup_"] [class*="mention"],
             [class*="markup_"] [class*="roleMention"],
             [class*="markup_"] a,

--- a/MoreRoleColors/MoreRoleColors.plugin.js
+++ b/MoreRoleColors/MoreRoleColors.plugin.js
@@ -336,6 +336,7 @@ module.exports = class MoreRoleColors {
             BdApi.Data.save('MoreRoleColors', 'lastVersion', this.meta.version);
         }
 
+        this.injectCSS();
         if (this.settings.voiceUsers) this.patchVoiceUsers();
         if (this.settings.typingUsers) this.patchTypingUsers();
         if (this.settings.mentions) this.patchMentions();
@@ -420,11 +421,27 @@ module.exports = class MoreRoleColors {
         if (this._unpatchAccountArea) this._unpatchAccountArea();
         if (this._unpatchUserProfile) this._unpatchUserProfile();
         if (this._unpatchTags) this._unpatchTags();
+        BdApi.DOM.removeStyle("MoreRoleColors");
         this.forceUpdateComponents();
     }
 
     onSwitch() {
         if (this.settings.accountArea) this.patchAccountArea();
+    }
+
+    injectCSS() {
+        BdApi.DOM.addStyle("MoreRoleColors", `
+            [class*="markup_"] code,
+            [class*="markup_"] pre,
+            [class*="markup_"] [class*="mention"],
+            [class*="markup_"] [class*="roleMention"],
+            [class*="markup_"] a,
+            [class*="markup_"] [class*="timestamp"],
+            [class*="markup_"] [class*="spoilerContent"],
+            [class*="markup_"] [class*="blockquoteContent"] {
+                -webkit-text-fill-color: initial !important;
+            }
+        `);
     }
 
     forceUpdateComponents() {

--- a/MoreRoleColors/MoreRoleColors.plugin.js
+++ b/MoreRoleColors/MoreRoleColors.plugin.js
@@ -871,16 +871,9 @@ module.exports = class MoreRoleColors {
             });
         }
 
-        try {
-            BdApi.Webpack.waitForModule(
-                m => m?.displayName === "ForwardRef(FluxContainer(GuildSettingsAuditLogEntry))",
-                { defaultExport: true, searchExports: false }
-            ).then((FluxContainerModule) => {
-                if (FluxContainerModule) attemptPatchAuditLogUser(FluxContainerModule);
-            }).catch(error => console.warn("[MoreRoleColors] Could not patch audit log", error));
-        } catch (error) {
-            console.warn("[MoreRoleColors] Could not search for the audit log module", error);
-        }
+        BdApi.Webpack.waitForModule(m => m.displayName === "ForwardRef(FluxContainer(GuildSettingsAuditLogEntry))").then((FluxContainerModule) => {
+            attemptPatchAuditLogUser(FluxContainerModule);
+        });
     }
 
     patchRoleHeaders() {

--- a/MoreRoleColors/MoreRoleColors.plugin.js
+++ b/MoreRoleColors/MoreRoleColors.plugin.js
@@ -446,8 +446,7 @@ module.exports = class MoreRoleColors {
                 text-decoration-color: var(--text-default, var(--text-normal, #dbdee1)) !important;
             }
 
-            [class*="markup_"] [class*="mention"],
-            [class*="markup_"] [class*="roleMention"],
+            [class*="markup_"] [class*="mention" i],
             [class*="markup_"] a,
             [class*="markup_"] [class*="timestamp"],
             [class*="markup_"] [class*="spoilerContent"],

--- a/MoreRoleColors/MoreRoleColors.plugin.js
+++ b/MoreRoleColors/MoreRoleColors.plugin.js
@@ -871,9 +871,16 @@ module.exports = class MoreRoleColors {
             });
         }
 
-        BdApi.Webpack.waitForModule(m => m.displayName === "ForwardRef(FluxContainer(GuildSettingsAuditLogEntry))").then((FluxContainerModule) => {
-            attemptPatchAuditLogUser(FluxContainerModule);
-        });
+        try {
+            BdApi.Webpack.waitForModule(
+                m => m?.displayName === "ForwardRef(FluxContainer(GuildSettingsAuditLogEntry))",
+                { defaultExport: true, searchExports: false }
+            ).then((FluxContainerModule) => {
+                if (FluxContainerModule) attemptPatchAuditLogUser(FluxContainerModule);
+            }).catch(error => console.warn("[MoreRoleColors] Could not patch audit log", error));
+        } catch (error) {
+            console.warn("[MoreRoleColors] Could not search for the audit log module", error);
+        }
     }
 
     patchRoleHeaders() {
@@ -907,6 +914,7 @@ module.exports = class MoreRoleColors {
         ).then((MessageContentMRC) => {
         BdApi.Patcher.after("MoreRoleColors-messages", MessageContentMRC, "type", (_, [props], res) => {
             if (!props?.message?.author?.id) return res;
+            if (props.message.type === 24) return res;
             
             const guildId = SelectedGuildStore.getGuildId();
             if (!guildId) return res;


### PR DESCRIPTION
When "Messages Coloring" with gradient is enabled, WebkitTextFillColor: "transparent" is set on the message container. This property inherits to all child elements (role mentions, code blocks, links, timestamps, etc.), making their text invisible since they don't have the parent's gradient background.

Fix: Added CSS that resets -webkit-text-fill-color: initial for child elements inside messages (mentions, code blocks, links, timestamps, spoilers, blockquotes) so they keep their normal text visibility while the message body still gets the gradient coloring.

Hopefully fixes #86 

<img width="1198" height="452" alt="image" src="https://github.com/user-attachments/assets/fd7aad83-fa7f-433a-a1b6-7072bde990b0" />
<img width="513" height="264" alt="image" src="https://github.com/user-attachments/assets/4f962541-b6cd-4429-b0cd-968ffa03f670" />
<img width="567" height="319" alt="image" src="https://github.com/user-attachments/assets/053c65a2-997b-46dd-a771-1d8457824589" />
